### PR TITLE
Add spelling settings

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -24,7 +24,7 @@
 
 (comment) @comment @spell
 
-(comment (reference (text) @string.special.path))
+(comment (reference (text) @string.special.path @nospell))
 
 (comment (flag (text) @label))
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -16,6 +16,8 @@
 
 (string) @string
 
+(msgstr (string (string_fragment) @spell))
+
 (escape_sequence) @string.escape
 
 (number) @number


### PR DESCRIPTION
It does not really make sense to spell-check file paths. On the other other hand it does make sense to spell-check the translated messages. Users probably have their editor set up to detect the language of a PO file, so the message strings should be checked while the untranslated message IDs should not. Or maybe they should be, I can add a commit for that too.

Personally I have my Neovim set up where it adds the language of the locale to the default language, i.e. if the global language is English and I am translating a German PO the `spelllang` will be set to `en,de`. But if a user has only one spelling language he would be getting a lot of false spelling errors if we spell-check the message IDs.

You can decide which one makes more sens.